### PR TITLE
Make bin dir configurable and default to /usr/bin

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,7 @@ class marathon (
   $install_java         = $marathon::params::install_java,
   $java_version         = $marathon::params::java_version,
   $init_style           = $marathon::params::init_style,
+  $bin_dir              = $marathon::params::bin_dir,
   $service_enable       = true,
   $service_ensure       = 'running',
   $extra_options        = '',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class marathon::params {
   $package_ensure    = 'latest'
   $install_java      = true
   $java_version      = 'java-1.7.0-openjdk'
+  $bin_dir           = '/usr/bin'
 
   $init_style = $::operatingsystem ? {
     'Ubuntu'             => $::lsbdistrelease ? {

--- a/templates/marathon.systemd.erb
+++ b/templates/marathon.systemd.erb
@@ -4,7 +4,7 @@ After=network.target
 Wants=network.target
 
 [Service]
-ExecStart=/usr/local/bin/marathon --master <%= scope.lookupvar('marathon::master') %> --zk <%= scope.lookupvar('marathon::zk') %> <%= scope.lookupvar('marathon::extra_options') %>
+ExecStart=<%= scope.lookupvar('marathon::bin_dir') %>/marathon --master <%= scope.lookupvar('marathon::master') %> --zk <%= scope.lookupvar('marathon::zk') %> <%= scope.lookupvar('marathon::extra_options') %>
 Restart=on-abort
 Restart=always
 RestartSec=20

--- a/templates/marathon.sysv.erb
+++ b/templates/marathon.sysv.erb
@@ -21,7 +21,7 @@
 . /etc/rc.d/init.d/functions
 
 prog="marathon"
-cmd="/usr/local/bin/${prog}"
+cmd="<%= scope.lookupvar('marathon::bin_dir') %>/${prog}"
 args="--master <%= scope.lookupvar('marathon::master') %> --zk <%= scope.lookupvar('marathon::zk') %> <%= scope.lookupvar('marathon::extra_options') %>"
 pidfile="/var/run/${prog}"
 lockfile=/var/lock/subsys/$prog

--- a/templates/marathon.upstart.erb
+++ b/templates/marathon.upstart.erb
@@ -6,4 +6,4 @@ stop on runlevel [!2345]
 respawn
 respawn limit 10 5
 
-exec /usr/local/bin/marathon --master <%= scope.lookupvar('marathon::master') %> --zk <%= scope.lookupvar('marathon::zk') %> <%= scope.lookupvar('marathon::extra_options') %>
+exec <%= scope.lookupvar('marathon::bin_dir') %>/marathon --master <%= scope.lookupvar('marathon::master') %> --zk <%= scope.lookupvar('marathon::zk') %> <%= scope.lookupvar('marathon::extra_options') %>


### PR DESCRIPTION
The releases for marathon packaged here https://github.com/mesosphere/marathon/releases

default to the marathon executable living at /usr/bin

I've made this a configurable option and set the default value to /usr/bin so any installs of marathon 0.8.0 should work