### PR TITLE
binary path was changed in marathon package

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,7 +7,7 @@ class marathon::params {
   $package_ensure    = 'latest'
   $install_java      = true
   $java_version      = 'java-1.7.0-openjdk'
-  $bin_path          = '/usr/local/bin'
+  $bin_path          = '/usr/bin'
 
   $init_style = $::operatingsystem ? {
     'Ubuntu'             => $::lsbdistrelease ? {


### PR DESCRIPTION
2015-01-13 in https://github.com/mesosphere/marathon-pkg/pull/7 from /usr/local/bin to
/usr/bin. make that the default now.