### PR TITLE
allow marathon class to setup Mesos authentication

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,10 +93,10 @@ class marathon (
 
   if $authenticate {
     if $auth_principal == undef {
-      fail("You must provide a principal when using authentication.")
+      fail('You must provide a principal when using authentication.')
     }
     if $auth_secret == undef {
-      fail("You must provide a secret when using authentication.")
+      fail('You must provide a secret when using authentication.')
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,27 @@
 # [*zk*]
 #   The ZooKeeper URL for storing state.
 #
+# [*authenticate*]
+#   Use Mesos Authentication (principle and secret) to authenticate with the master
+#   default: false
+#
+# [*auth_principal*]
+#   Principal to use when authenticating with Mesos.
+#   See Mesos authentication and ACL's for more info.
+#
+#   Required if authenticate => true
+#
+# [*auth_secret*]
+#   Secret to use for authentication with principal.  It is a good idea to encrypt this,
+#   out of the box Mesos is configured to use HTTP.
+#
+#   Required if authenticate => true
+#
+# [*secret_file*]
+#   File in which to store our secret for slave authentication
+#
+#   Required if authenticate => true
+
 # === Examples
 #
 #  class { marathon:
@@ -56,13 +77,29 @@ class marathon (
   $manage_user          = false,
   $user                 = 'root',
   $group                = undef,
-  $manage_repo          = false
+  $manage_repo          = false,
+  $authenticate         = false,
+  $secret_file          = '/etc/mesos/marathon.secret',
+  $auth_principal       = undef,
+  $auth_secret          = undef,
+  $auth_role            = undef
+
 ) inherits marathon::params {
 
   validate_bool($install_java)
   validate_bool($service_enable)
   validate_bool($manage_user)
   validate_bool($manage_repo)
+
+  if $authenticate {
+    if $auth_principal == undef {
+      fail("You must provide a principal when using authentication.")
+    }
+    if $auth_secret == undef {
+      fail("You must provide a secret when using authentication.")
+    }
+  }
+
 
   class { 'marathon::install': } ->
   class { 'marathon::service': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,6 +90,7 @@ class marathon (
   validate_bool($service_enable)
   validate_bool($manage_user)
   validate_bool($manage_repo)
+  validate_bool($authenticate)
 
   if $authenticate {
     if $auth_principal == undef {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -118,4 +118,19 @@ class marathon::install {
       }
     }
   }
+
+  if $marathon::authenticate  {
+    file { 'marathon-secret-file':
+      path    => $marathon::secret_file,
+      ensure  => file,
+      mode    => '0600',
+      owner   => $real_user,
+      group   => $real_group,
+      content => $marathon::auth_secret,
+      before  => Service['marathon'],
+      notify  => Service['marathon']
+    }
+  }
+
+
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -121,8 +121,8 @@ class marathon::install {
 
   if $marathon::authenticate  {
     file { 'marathon-secret-file':
-      path    => $marathon::secret_file,
       ensure  => file,
+      path    => $marathon::secret_file,
       mode    => '0600',
       owner   => $real_user,
       group   => $real_group,

--- a/templates/marathon.systemd.erb
+++ b/templates/marathon.systemd.erb
@@ -4,7 +4,17 @@ After=network.target
 Wants=network.target
 
 [Service]
-ExecStart=<%= scope.lookupvar('marathon::bin_path') %>/marathon --master <%= scope.lookupvar('marathon::master') %> --zk <%= scope.lookupvar('marathon::zk') %> <%= scope.lookupvar('marathon::extra_options') %>
+ExecStart=<%= scope.lookupvar('marathon::bin_path') %>/marathon \
+--master <%= scope.lookupvar('marathon::master') %> \
+--zk <%= scope.lookupvar('marathon::zk') %> \
+<% if scope.lookupvar('marathon::authenticate') -%>
+    --mesos_authentication_principal <%= scope.lookupvar('marathon::auth_principal') %> \
+    --mesos_authentication_secret_file <%= scope.lookupvar('marathon::secret_file') %> \
+    <%- if scope.lookupvar('marathon::auth_role') -%>
+        --mesos_role <%= scope.lookupvar('marathon::auth_role') %> \
+    <% end -%>
+<% end -%>
+<%= scope.lookupvar('marathon::extra_options') %>
 Restart=on-abort
 Restart=always
 RestartSec=20

--- a/templates/marathon.sysv.erb
+++ b/templates/marathon.sysv.erb
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# marathon 
+# marathon
 #
 # chkconfig:   2345 55 25
 # description: marathon for mesos
@@ -9,8 +9,8 @@
 # Provides: marathon
 # Required-Start: $local_fs $network
 # Required-Stop: $local_fs $network
-# Should-Start: 
-# Should-Stop: 
+# Should-Start:
+# Should-Stop:
 # Default-Start: 2 3 4 5
 # Default-Stop: 0 1 6
 # Short-Description: Startup the Marathon framework
@@ -22,7 +22,16 @@
 
 prog="marathon"
 cmd="<%= scope.lookupvar('marathon::bin_path') %>/${prog}"
-args="--master <%= scope.lookupvar('marathon::master') %> --zk <%= scope.lookupvar('marathon::zk') %> <%= scope.lookupvar('marathon::extra_options') %>"
+args="--master <%= scope.lookupvar('marathon::master') %> \
+--zk <%= scope.lookupvar('marathon::zk') %> \
+<%- if scope.lookupvar('marathon::authenticate') -%>
+    --mesos_authentication_principal <%= scope.lookupvar('marathon::auth_principal') %> \
+    --mesos_authentication_secret_file <%= scope.lookupvar('marathon::secret_file') %> \
+    <%- if scope.lookupvar('marathon::auth_role') -%>
+        --mesos_role <%= scope.lookupvar('marathon::auth_role') %> \
+    <% end -%>
+<% end -%>
+<%= scope.lookupvar('marathon::extra_options') %>"
 pidfile="/var/run/${prog}"
 lockfile=/var/lock/subsys/$prog
 

--- a/templates/marathon.upstart.erb
+++ b/templates/marathon.upstart.erb
@@ -6,4 +6,16 @@ stop on runlevel [!2345]
 respawn
 respawn limit 10 5
 
-exec su -c '<%= scope.lookupvar('marathon::bin_path') %>/marathon --master <%= scope.lookupvar('marathon::master') %> --zk <%= scope.lookupvar('marathon::zk') %> <%= scope.lookupvar('marathon::extra_options') %>' - <%= scope.lookupvar('marathon::user') %>
+setuid <%= scope.lookupvar('marathon::user') %>
+
+exec <%= scope.lookupvar('marathon::bin_path') %>/marathon \
+--master <%= scope.lookupvar('marathon::master') %> \
+--zk <%= scope.lookupvar('marathon::zk') %> \
+<%- if scope.lookupvar('marathon::authenticate') -%>
+    --mesos_authentication_principal <%= scope.lookupvar('marathon::auth_principal') %> \
+    --mesos_authentication_secret_file <%= scope.lookupvar('marathon::secret_file') %> \
+    <%- if scope.lookupvar('marathon::auth_role') -%>
+        --mesos_role <%= scope.lookupvar('marathon::auth_role') %> \
+    <% end -%>
+<% end -%>
+<%= scope.lookupvar('marathon::extra_options') %>


### PR DESCRIPTION
This change allows for explicitly using Mesos Authentication and providing principle and secret to authenticate with. 

I realized in writing up this request that these settings can probably be accomplished by using the `extra_options` param but that's not very clear to the developer.  If we explicitly provide these parameters its much more clear and easier to enable authentication and therefore helping to promote good practices when deploying a new Mesos cluster.

I'm not entirely confident the sysv and upstart init scripts will work as expected, I don't have access right now to boxes to test that, but the systemd version is working for me on CentOS7.

If you want tests, please let me know. currently I'm having issues running the suite.  
