### PR TITLE
Redhat systems need to use 'redhat', not 'init'

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -112,6 +112,18 @@ class marathon::install {
           notify  => Service['marathon']
         }
       }
+      'redhat' : {
+        file { 'marathon-conf':
+          ensure  => file,
+          path    => '/etc/init.d/marathon',
+          owner   => $real_user,
+          group   => $real_group,
+          mode    => '0755',
+          content => template('marathon/marathon.sysv.erb'),
+          before  => Service['marathon'],
+          notify  => Service['marathon']
+        }
+      }
       default : {
         fail("I don't know how to create an init script \
           for style ${marathon::init_style}")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,7 +16,7 @@ class marathon::params {
       default => undef
     },
     /CentOS|RedHat|OracleLinux/      => $::operatingsystemmajrelease ? {
-      /(4|5|6)/ => 'sysv',
+      /(4|5|6)/ => 'redhat',
       default   => 'systemd',
     },
     'Fedora'             => $::operatingsystemmajrelease ? {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,7 +5,7 @@
 class marathon::service {
 
   $provider = $marathon::init_style ? {
-    'sysv'  => 'init',
+    'sysv'  => 'redhat',
     default => $marathon::init_style
   }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,7 +5,7 @@
 class marathon::service {
 
   $provider = $marathon::init_style ? {
-    'sysv'  => 'redhat',
+    'sysv'  => 'init',
     default => $marathon::init_style
   }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -29,6 +29,10 @@ describe 'marathon', :type => 'class' do
           :ensure => 'file',
           :path   => '/etc/init.d/marathon'
           }) }
+
+        it { should contain_service('marathon').with({
+          :provider => 'redhat'
+          }) }
       end
 
       if operatingsystem == 'Fedora'


### PR DESCRIPTION
I believe that Redhat-derived systems are the only ones still using sysv style inits, so they should use the 'redhat' provider.  

A reference: https://docs.puppet.com/puppet/latest/reference/type.html#service-provider-redhat